### PR TITLE
Fix `SPI` clocks and `rtc_watchdog` example 

### DIFF
--- a/esp-hal-common/src/rtc_cntl/mod.rs
+++ b/esp-hal-common/src/rtc_cntl/mod.rs
@@ -694,7 +694,7 @@ impl WatchdogDisable for Rwdt {
     }
 }
 
-//TODO: this can be refactored
+// TODO: this can be refactored
 impl WatchdogEnable for Rwdt {
     type Time = MicrosDurationU64;
 
@@ -717,9 +717,10 @@ impl WatchdogEnable for Rwdt {
                 .modify(|_, w| w.wdt_stg0_hold().bits(timeout_raw));
 
             #[cfg(esp32c6)]
-            (&*LP_WDT::PTR)
-                .config1
-                .modify(|_, w| w.wdt_stg0_hold().bits(timeout_raw >> (1 + Efuse::get_rwdt_multiplier())));
+            (&*LP_WDT::PTR).config1.modify(|_, w| {
+                w.wdt_stg0_hold()
+                    .bits(timeout_raw >> (1 + Efuse::get_rwdt_multiplier()))
+            });
 
             #[cfg(not(any(esp32, esp32c6)))]
             rtc_cntl.wdtconfig1.modify(|_, w| {

--- a/esp-hal-common/src/rtc_cntl/mod.rs
+++ b/esp-hal-common/src/rtc_cntl/mod.rs
@@ -6,7 +6,7 @@ use fugit::MicrosDurationU64;
 use self::rtc::SocResetReason;
 #[cfg(not(esp32c6))]
 use crate::clock::{Clock, XtalClock};
-#[cfg(not(any(esp32, esp32c6)))]
+#[cfg(not(esp32))]
 use crate::efuse::Efuse;
 #[cfg(esp32c6)]
 use crate::peripherals::LP_WDT;
@@ -694,6 +694,7 @@ impl WatchdogDisable for Rwdt {
     }
 }
 
+//TODO: this can be refactored
 impl WatchdogEnable for Rwdt {
     type Time = MicrosDurationU64;
 
@@ -718,7 +719,7 @@ impl WatchdogEnable for Rwdt {
             #[cfg(esp32c6)]
             (&*LP_WDT::PTR)
                 .config1
-                .modify(|_, w| w.wdt_stg0_hold().bits(timeout_raw));
+                .modify(|_, w| w.wdt_stg0_hold().bits(timeout_raw >> (1 + Efuse::get_rwdt_multiplier())));
 
             #[cfg(not(any(esp32, esp32c6)))]
             rtc_cntl.wdtconfig1.modify(|_, w| {

--- a/esp-hal-common/src/spi.rs
+++ b/esp-hal-common/src/spi.rs
@@ -1332,9 +1332,9 @@ pub trait Instance {
 
         #[cfg(esp32c6)]
         unsafe {
-            let pcr =  &*esp32c6::PCR::PTR;
+            let pcr = &*esp32c6::PCR::PTR;
 
-            pcr.spi2_clkm_conf.modify(|_,w| w.spi2_clkm_sel().bits(1));
+            pcr.spi2_clkm_conf.modify(|_, w| w.spi2_clkm_sel().bits(1));
         }
 
         reg_block.ctrl.write(|w| unsafe { w.bits(0) });

--- a/esp-hal-common/src/spi.rs
+++ b/esp-hal-common/src/spi.rs
@@ -1334,6 +1334,7 @@ pub trait Instance {
         unsafe {
             let pcr = &*esp32c6::PCR::PTR;
 
+            // use default clock source PLL_F80M_CLK
             pcr.spi2_clkm_conf.modify(|_, w| w.spi2_clkm_sel().bits(1));
         }
 

--- a/esp-hal-common/src/spi.rs
+++ b/esp-hal-common/src/spi.rs
@@ -1330,6 +1330,13 @@ pub trait Instance {
                 .set_bit()
         });
 
+        #[cfg(esp32c6)]
+        unsafe {
+            let pcr =  &*esp32c6::PCR::PTR;
+
+            pcr.spi2_clkm_conf.modify(|_,w| w.spi2_clkm_sel().bits(1));
+        }
+
         reg_block.ctrl.write(|w| unsafe { w.bits(0) });
 
         #[cfg(not(esp32))]

--- a/esp32c6-hal/examples/rtc_watchdog.rs
+++ b/esp32c6-hal/examples/rtc_watchdog.rs
@@ -15,6 +15,7 @@ use esp32c6_hal::{
     peripherals::{self, Peripherals},
     prelude::*,
     riscv,
+    timer::TimerGroup,
     Rtc,
     Rwdt,
 };
@@ -26,8 +27,15 @@ static RWDT: Mutex<RefCell<Option<Rwdt>>> = Mutex::new(RefCell::new(None));
 fn main() -> ! {
     let peripherals = Peripherals::take();
     let system = peripherals.PCR.split();
-    let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+    let mut wdt0 = timer_group0.wdt;
+    let timer_group1 = TimerGroup::new(peripherals.TIMG1, &clocks);
+    let mut wdt1 = timer_group1.wdt;
+
+    wdt0.disable();
+    wdt1.disable();
     let mut rtc = Rtc::new(peripherals.LP_CLKRST);
 
     // Disable watchdog timers


### PR DESCRIPTION
This PR should resolve the issues marked as `clock` issues [here](https://github.com/esp-rs/esp-hal/pull/392#issuecomment-1443998586) in SPI examples and should fix (at least now is closer to 5secs than before) the `rtc_watchdog` delay ~~in BL mode.~~