### PR TITLE
Fix RMT examples

### DIFF
--- a/examples/src/bin/embassy_rmt_rx.rs
+++ b/examples/src/bin/embassy_rmt_rx.rs
@@ -1,8 +1,5 @@
 //! Demonstrates decoding pulse sequences with RMT
-//!
-//! This uses the boot button as input - press the button a couple of
-//! times to generate a pulse sequence and then wait for the idle timeout to see
-//! the recorded pulse sequence
+//! Connect GPIO5 to GPIO4
 
 //% CHIPS: esp32 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
 //% FEATURES: async embassy embassy-executor-thread embassy-time-timg0
@@ -12,14 +9,15 @@
 #![feature(type_alias_impl_trait)]
 
 use embassy_executor::Spawner;
+use embassy_time::{Duration, Timer};
 use esp_backtrace as _;
 use esp_hal::{
     clock::ClockControl,
     embassy::{self},
+    gpio::{Gpio5, Output, PushPull},
     peripherals::Peripherals,
     prelude::*,
     rmt::{asynch::RxChannelAsync, PulseCode, RxChannelConfig, RxChannelCreator},
-    timer::TimerGroup,
     Rmt,
     IO,
 };
@@ -27,19 +25,43 @@ use esp_println::{print, println};
 
 const WIDTH: usize = 80;
 
+#[cfg(debug_assertions)]
+compile_error!("Run this example in release mode");
+
+#[embassy_executor::task]
+async fn signal_task(mut pin: Gpio5<Output<PushPull>>) {
+    loop {
+        for _ in 0..10 {
+            pin.toggle().unwrap();
+            Timer::after(Duration::from_micros(10)).await;
+        }
+        Timer::after(Duration::from_millis(1000)).await;
+    }
+}
+
 #[main]
-async fn main(_spawner: Spawner) {
+async fn main(spawner: Spawner) {
+    #[cfg(feature = "log")]
+    esp_println::logger::init_logger_from_env();
     println!("Init!");
     let peripherals = Peripherals::take();
     let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    let timg0 = TimerGroup::new(peripherals.TIMG0, &clocks);
-    embassy::init(&clocks, timg0);
+    let timer_group0 = esp_hal::timer::TimerGroup::new(peripherals.TIMG0, &clocks);
+    embassy::init(&clocks, timer_group0);
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let rmt = Rmt::new(peripherals.RMT, 8u32.MHz(), &clocks).unwrap();
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "esp32h2")] {
+            let freq = 32u32.MHz();
+        } else {
+            let freq = 80u32.MHz();
+        }
+    };
+
+    let rmt = Rmt::new(peripherals.RMT, freq, &clocks).unwrap();
     let rx_config = RxChannelConfig {
         clk_divider: 255,
         idle_threshold: 10000,
@@ -48,13 +70,17 @@ async fn main(_spawner: Spawner) {
 
     cfg_if::cfg_if! {
         if #[cfg(any(feature = "esp32", feature = "esp32s2"))] {
-            let mut channel = rmt.channel0.configure(io.pins.gpio0, rx_config).unwrap();
+            let mut channel = rmt.channel0.configure(io.pins.gpio4, rx_config).unwrap();
         } else if #[cfg(feature = "esp32s3")] {
-            let mut channel = rmt.channel7.configure(io.pins.gpio0, rx_config).unwrap();
+            let mut channel = rmt.channel7.configure(io.pins.gpio4, rx_config).unwrap();
         } else {
-            let mut channel = rmt.channel2.configure(io.pins.gpio0, rx_config).unwrap();
+            let mut channel = rmt.channel2.configure(io.pins.gpio4, rx_config).unwrap();
         }
     }
+
+    spawner
+        .spawn(signal_task(io.pins.gpio5.into_push_pull_output()))
+        .unwrap();
 
     let mut data = [PulseCode {
         level1: true,
@@ -66,7 +92,6 @@ async fn main(_spawner: Spawner) {
     loop {
         println!("receive");
         channel.receive(&mut data).await.unwrap();
-        println!("received");
         let mut total = 0usize;
         for entry in &data[..data.len()] {
             if entry.length1 == 0 {

--- a/examples/src/bin/embassy_rmt_rx.rs
+++ b/examples/src/bin/embassy_rmt_rx.rs
@@ -41,8 +41,6 @@ async fn signal_task(mut pin: Gpio5<Output<PushPull>>) {
 
 #[main]
 async fn main(spawner: Spawner) {
-    #[cfg(feature = "log")]
-    esp_println::logger::init_logger_from_env();
     println!("Init!");
     let peripherals = Peripherals::take();
     let system = peripherals.SYSTEM.split();

--- a/examples/src/bin/embassy_rmt_tx.rs
+++ b/examples/src/bin/embassy_rmt_tx.rs
@@ -1,6 +1,6 @@
 //! Demonstrates generating pulse sequences with RMT
 //!
-//! Connect a logic analyzer to GPIO1 to see the generated pulses.
+//! Connect a logic analyzer to GPIO4 to see the generated pulses.
 
 //% CHIPS: esp32 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
 //% FEATURES: async embassy embassy-executor-thread embassy-time-timg0
@@ -36,12 +36,20 @@ async fn main(_spawner: Spawner) {
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let rmt = Rmt::new(peripherals.RMT, 8u32.MHz(), &clocks).unwrap();
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "esp32h2")] {
+            let freq = 32u32.MHz();
+        } else {
+            let freq = 80u32.MHz();
+        }
+    };
+
+    let rmt = Rmt::new(peripherals.RMT, freq, &clocks).unwrap();
 
     let mut channel = rmt
         .channel0
         .configure(
-            io.pins.gpio1.into_push_pull_output(),
+            io.pins.gpio4.into_push_pull_output(),
             TxChannelConfig {
                 clk_divider: 255,
                 ..TxChannelConfig::default()

--- a/examples/src/bin/rmt_tx.rs
+++ b/examples/src/bin/rmt_tx.rs
@@ -1,6 +1,6 @@
 //! Demonstrates generating pulse sequences with RMT
 //!
-//! Connect a logic analyzer to GPIO0 to see the generated pulses.
+//! Connect a logic analyzer to GPIO4 to see the generated pulses.
 
 //% CHIPS: esp32 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
 
@@ -26,13 +26,22 @@ fn main() -> ! {
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
-    let rmt = Rmt::new(peripherals.RMT, 8u32.MHz(), &clocks).unwrap();
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "esp32h2")] {
+            let freq = 32u32.MHz();
+        } else {
+            let freq = 80u32.MHz();
+        }
+    };
+
+    let rmt = Rmt::new(peripherals.RMT, freq, &clocks).unwrap();
+
     let tx_config = TxChannelConfig {
         clk_divider: 255,
         ..TxChannelConfig::default()
     };
 
-    let mut channel = rmt.channel0.configure(io.pins.gpio0, tx_config).unwrap();
+    let mut channel = rmt.channel0.configure(io.pins.gpio4, tx_config).unwrap();
 
     let mut delay = Delay::new(&clocks);
 


### PR DESCRIPTION
- RX examples are now not interactive anymore (need to short two pins) to make them work on ESP32 / ESP32-S2
- use a different frequency for H2 since it cannot reach 80MHz
- use GPIO 4 (and GPIO 5) to avoid conflicting with GPIO 1 and 3 on ESP32
- use GPIOs consistently (i.e. same for async and non-async examples)
