### PR TITLE
Make I2S examples work on ESP32

### DIFF
--- a/examples/src/bin/embassy_i2s_read.rs
+++ b/examples/src/bin/embassy_i2s_read.rs
@@ -1,10 +1,10 @@
 //! This shows how to continously receive data via I2S.
 //!
 //! Pins used:
-//! MCLK    GPIO0
-//! BCLK    GPIO1
-//! WS      GPIO2
-//! DIN     GPIO3
+//! MCLK    GPIO0 (not ESP32)
+//! BCLK    GPIO2
+//! WS      GPIO4
+//! DIN     GPIO5
 //!
 //! Without an additional I2S source device you can connect 3V3 or GND to DIN
 //! to read 0 or 0xFF or connect DIN to WS to read two different values.
@@ -67,14 +67,18 @@ async fn main(_spawner: Spawner) {
             DmaPriority::Priority0,
         ),
         &clocks,
-    )
-    .with_mclk(io.pins.gpio0);
+    );
+
+    #[cfg(esp32)]
+    {
+        i2s.with_mclk(io.pins.gpio0);
+    }
 
     let i2s_rx = i2s
         .i2s_rx
-        .with_bclk(io.pins.gpio1)
-        .with_ws(io.pins.gpio2)
-        .with_din(io.pins.gpio3)
+        .with_bclk(io.pins.gpio2)
+        .with_ws(io.pins.gpio4)
+        .with_din(io.pins.gpio5)
         .build();
 
     let buffer = rx_buffer;

--- a/examples/src/bin/embassy_i2s_read.rs
+++ b/examples/src/bin/embassy_i2s_read.rs
@@ -35,8 +35,6 @@ use esp_println::println;
 
 #[main]
 async fn main(_spawner: Spawner) {
-    #[cfg(feature = "log")]
-    esp_println::logger::init_logger_from_env();
     println!("Init!");
     let peripherals = Peripherals::take();
     let system = peripherals.SYSTEM.split();

--- a/examples/src/bin/embassy_i2s_sound.rs
+++ b/examples/src/bin/embassy_i2s_sound.rs
@@ -1,12 +1,11 @@
 //! This shows how to transmit data continously via I2S.
 //!
 //! Pins used:
-//! MCLK    GPIO0
-//! BCLK    GPIO1
-//! WS      GPIO2
-//! DOUT    GPIO3
+//! BCLK    GPIO2
+//! WS      GPIO4
+//! DOUT    GPIO5
 //!
-//! Without an additional I2S sink device you can inspect the MCLK, BCLK, WS
+//! Without an additional I2S sink device you can inspect the BCLK, WS
 //! and DOUT with a logic analyzer.
 //!
 //! You can also connect e.g. a PCM510x to hear an annoying loud sine tone (full
@@ -91,14 +90,13 @@ async fn main(_spawner: Spawner) {
             DmaPriority::Priority0,
         ),
         &clocks,
-    )
-    .with_mclk(io.pins.gpio0);
+    );
 
     let i2s_tx = i2s
         .i2s_tx
-        .with_bclk(io.pins.gpio1)
-        .with_ws(io.pins.gpio2)
-        .with_dout(io.pins.gpio3)
+        .with_bclk(io.pins.gpio2)
+        .with_ws(io.pins.gpio4)
+        .with_dout(io.pins.gpio5)
         .build();
 
     let data =

--- a/examples/src/bin/embassy_i2s_sound.rs
+++ b/examples/src/bin/embassy_i2s_sound.rs
@@ -58,8 +58,6 @@ const SINE: [i16; 64] = [
 
 #[main]
 async fn main(_spawner: Spawner) {
-    #[cfg(feature = "log")]
-    esp_println::logger::init_logger_from_env();
     println!("Init!");
     let peripherals = Peripherals::take();
     let system = peripherals.SYSTEM.split();

--- a/examples/src/bin/i2s_read.rs
+++ b/examples/src/bin/i2s_read.rs
@@ -1,10 +1,10 @@
 //! This shows how to continously receive data via I2S.
 //!
 //! Pins used:
-//! MCLK    GPIO0
-//! BCLK    GPIO1
-//! WS      GPIO2
-//! DIN     GPIO3
+//! MCLK    GPIO0 (not ESP32)
+//! BCLK    GPIO2
+//! WS      GPIO4
+//! DIN     GPIO5
 //!
 //! Without an additional I2S source device you can connect 3V3 or GND to DIN
 //! to read 0 or 0xFF or connect DIN to WS to read two different values.
@@ -60,14 +60,18 @@ fn main() -> ! {
             DmaPriority::Priority0,
         ),
         &clocks,
-    )
-    .with_mclk(io.pins.gpio0);
+    );
+
+    #[cfg(esp32)]
+    {
+        i2s.with_mclk(io.pins.gpio0);
+    }
 
     let i2s_rx = i2s
         .i2s_rx
-        .with_bclk(io.pins.gpio1)
-        .with_ws(io.pins.gpio2)
-        .with_din(io.pins.gpio3)
+        .with_bclk(io.pins.gpio2)
+        .with_ws(io.pins.gpio4)
+        .with_din(io.pins.gpio5)
         .build();
 
     let buffer = rx_buffer;

--- a/examples/src/bin/i2s_sound.rs
+++ b/examples/src/bin/i2s_sound.rs
@@ -1,9 +1,9 @@
 //! This shows how to transmit data continously via I2S.
 //!
 //! Pins used:
-//! BCLK    GPIO0
-//! WS      GPIO1
-//! DOUT    GPIO2
+//! BCLK    GPIO2
+//! WS      GPIO4
+//! DOUT    GPIO5
 //!
 //! Without an additional I2S sink device you can inspect the MCLK, BCLK, WS
 //!  andDOUT with a logic analyzer.
@@ -82,9 +82,9 @@ fn main() -> ! {
 
     let i2s_tx = i2s
         .i2s_tx
-        .with_bclk(io.pins.gpio0)
-        .with_ws(io.pins.gpio1)
-        .with_dout(io.pins.gpio2)
+        .with_bclk(io.pins.gpio2)
+        .with_ws(io.pins.gpio4)
+        .with_dout(io.pins.gpio5)
         .build();
 
     let data =


### PR DESCRIPTION
- avoid using ESP32 UART pins
- don't use MCLK in RX examples
- don't try to use MCLK for ESP32 in TX examples
