### PR TITLE
Embassy timer example fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `DAC` driver's constructor is now `new` instead of `dac`, to be more consistent with other APIs (#1100)
 - The DMA peripheral is now called `Dma` for devices with both PDMA and GDMA controllers (#1125)
 - The `ADC` driver's constructor is now `new` instead of `adc`, to be more consistent with other APIs (#1133)
+- `embassy-executor`'s `integrated-timers` is no longer enabled by default.
 
 ## [0.15.0] - 2024-01-19
 

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -66,7 +66,7 @@ basic-toml = "0.1.8"
 serde      = { version = "1.0.195", features = ["derive"] }
 
 [features]
-default = ["embassy-integrated-timers", "rt", "vectored"]
+default = ["rt", "vectored"]
 
 riscv  = ["dep:riscv",     "critical-section/restore-state-u8",  "esp-riscv-rt?/zero-bss"]
 xtensa = ["dep:xtensa-lx", "critical-section/restore-state-u32"]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -54,12 +54,13 @@ async = ["esp-hal/async"]
 
 eh1 = ["esp-hal/eh1"]
 
-embassy = ["esp-hal/embassy", "esp-hal/embassy-integrated-timers"]
+embassy = ["esp-hal/embassy"]
 
 embassy-executor-thread    = ["esp-hal/embassy-executor-thread"]
 embassy-executor-interrupt = ["esp-hal/embassy-executor-interrupt"]
 
 embassy-time-timg0 = ["esp-hal/embassy-time-timg0", "embassy-time-driver/tick-hz-1_000_000"]
+embassy-generic-timers = ["embassy-time/generic-queue-8"]
 
 direct-vectoring     = ["esp-hal/direct-vectoring"]
 interrupt-preemption = ["esp-hal/interrupt-preemption"]

--- a/examples/src/bin/embassy_hello_world.rs
+++ b/examples/src/bin/embassy_hello_world.rs
@@ -4,7 +4,7 @@
 //! concurrently.
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
-//% FEATURES: embassy embassy-time-timg0 embassy-executor-thread
+//% FEATURES: embassy embassy-time-timg0 embassy-executor-thread embassy-generic-timers
 
 #![no_std]
 #![no_main]

--- a/examples/src/bin/embassy_i2c.rs
+++ b/examples/src/bin/embassy_i2c.rs
@@ -11,7 +11,7 @@
 //! LIS3DH to get accelerometer data.
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
-//% FEATURES: async embassy embassy-executor-thread embassy-time-timg0
+//% FEATURES: async embassy embassy-executor-thread embassy-time-timg0 embassy-generic-timers
 
 #![no_std]
 #![no_main]

--- a/examples/src/bin/embassy_i2s_read.rs
+++ b/examples/src/bin/embassy_i2s_read.rs
@@ -12,7 +12,7 @@
 //! You can also inspect the MCLK, BCLK and WS with a logic analyzer.
 
 //% CHIPS: esp32 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
-//% FEATURES: async embassy embassy-executor-thread embassy-time-timg0
+//% FEATURES: async embassy embassy-executor-thread embassy-time-timg0 embassy-generic-timers
 
 #![no_std]
 #![no_main]

--- a/examples/src/bin/embassy_i2s_sound.rs
+++ b/examples/src/bin/embassy_i2s_sound.rs
@@ -27,7 +27,7 @@
 //! | XSMT  | +3V3            |
 
 //% CHIPS: esp32 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
-//% FEATURES: async embassy embassy-executor-thread embassy-time-timg0
+//% FEATURES: async embassy embassy-executor-thread embassy-time-timg0 embassy-generic-timers
 
 #![no_std]
 #![no_main]

--- a/examples/src/bin/embassy_multicore.rs
+++ b/examples/src/bin/embassy_multicore.rs
@@ -4,7 +4,7 @@
 //! signal set by the task running on the other core.
 
 //% CHIPS: esp32 esp32s3
-//% FEATURES: embassy embassy-executor-thread embassy-time-timg0
+//% FEATURES: embassy embassy-executor-thread embassy-time-timg0 embassy-generic-timers
 
 #![no_std]
 #![no_main]

--- a/examples/src/bin/embassy_multicore_interrupt.rs
+++ b/examples/src/bin/embassy_multicore_interrupt.rs
@@ -4,7 +4,7 @@
 //! signal set by the task running on the other core.
 
 //% CHIPS: esp32 esp32s3
-//% FEATURES: embassy embassy-executor-interrupt embassy-time-timg0
+//% FEATURES: embassy embassy-executor-interrupt embassy-time-timg0 embassy-generic-timers
 
 #![no_std]
 #![no_main]

--- a/examples/src/bin/embassy_multiprio.rs
+++ b/examples/src/bin/embassy_multiprio.rs
@@ -13,7 +13,7 @@
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
 // FIXME: We should not need *two* executor features enabled here...
-//% FEATURES: embassy embassy-executor-interrupt embassy-executor-thread embassy-time-timg0
+//% FEATURES: embassy embassy-executor-interrupt embassy-executor-thread embassy-time-timg0 embassy-generic-timers
 
 #![no_std]
 #![no_main]

--- a/examples/src/bin/embassy_parl_io_rx.rs
+++ b/examples/src/bin/embassy_parl_io_rx.rs
@@ -4,7 +4,7 @@
 //! Uses GPIO 1, 2, 3 and 4 as the data pins.
 
 //% CHIPS: esp32c6 esp32h2
-//% FEATURES: async embassy embassy-executor-thread embassy-time-timg0
+//% FEATURES: async embassy embassy-executor-thread embassy-time-timg0 embassy-generic-timers
 
 #![no_std]
 #![no_main]

--- a/examples/src/bin/embassy_parl_io_tx.rs
+++ b/examples/src/bin/embassy_parl_io_tx.rs
@@ -8,7 +8,7 @@
 //! You can use a logic analyzer to see how the pins are used.
 
 //% CHIPS: esp32c6 esp32h2
-//% FEATURES: async embassy embassy-executor-thread embassy-time-timg0
+//% FEATURES: async embassy embassy-executor-thread embassy-time-timg0 embassy-generic-timers
 
 #![no_std]
 #![no_main]

--- a/examples/src/bin/embassy_rmt_rx.rs
+++ b/examples/src/bin/embassy_rmt_rx.rs
@@ -2,7 +2,7 @@
 //! Connect GPIO5 to GPIO4
 
 //% CHIPS: esp32 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
-//% FEATURES: async embassy embassy-executor-thread embassy-time-timg0
+//% FEATURES: async embassy embassy-executor-thread embassy-time-timg0 embassy-generic-timers
 
 #![no_std]
 #![no_main]

--- a/examples/src/bin/embassy_rmt_tx.rs
+++ b/examples/src/bin/embassy_rmt_tx.rs
@@ -3,7 +3,7 @@
 //! Connect a logic analyzer to GPIO4 to see the generated pulses.
 
 //% CHIPS: esp32 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
-//% FEATURES: async embassy embassy-executor-thread embassy-time-timg0
+//% FEATURES: async embassy embassy-executor-thread embassy-time-timg0 embassy-generic-timers
 
 #![no_std]
 #![no_main]

--- a/examples/src/bin/embassy_serial.rs
+++ b/examples/src/bin/embassy_serial.rs
@@ -8,7 +8,7 @@
 #![feature(type_alias_impl_trait)]
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
-//% FEATURES: async embassy embassy-executor-thread embassy-time-timg0
+//% FEATURES: async embassy embassy-executor-thread embassy-time-timg0 embassy-generic-timers
 
 use embassy_executor::Spawner;
 use embassy_sync::{blocking_mutex::raw::NoopRawMutex, signal::Signal};

--- a/examples/src/bin/embassy_spi.rs
+++ b/examples/src/bin/embassy_spi.rs
@@ -15,7 +15,7 @@
 //! This is an example of running the embassy executor with SPI.
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
-//% FEATURES: async embassy embassy-executor-thread embassy-time-timg0
+//% FEATURES: async embassy embassy-executor-thread embassy-time-timg0 embassy-generic-timers
 
 #![no_std]
 #![no_main]

--- a/examples/src/bin/embassy_usb_serial_jtag.rs
+++ b/examples/src/bin/embassy_usb_serial_jtag.rs
@@ -3,7 +3,7 @@
 //! Most dev-kits use a USB-UART-bridge - in that case you won't see any output.
 
 //% CHIPS: esp32c3 esp32c6 esp32h2 esp32s3
-//% FEATURES: async embassy embassy-executor-thread embassy-time-timg0
+//% FEATURES: async embassy embassy-executor-thread embassy-time-timg0 embassy-generic-timers
 
 #![no_std]
 #![no_main]

--- a/examples/src/bin/embassy_wait.rs
+++ b/examples/src/bin/embassy_wait.rs
@@ -3,7 +3,7 @@
 //! This is an example of asynchronously `Wait`ing for a pin state to change.
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
-//% FEATURES: async embassy embassy-executor-thread embassy-time-timg0
+//% FEATURES: async embassy embassy-executor-thread embassy-time-timg0 embassy-generic-timers
 
 #![no_std]
 #![no_main]


### PR DESCRIPTION
The `integrated` timer feature for the esp32c3 and esp32s3 is somewhat crippled when combined with timg0, because it only has one timer. This works for one executor but the multiprio example fails. This changes two things:

* Don't enable any embassy related features in esp-hal.
* Update the esp-hal examples to use the generic queue timers to be consistent across examples.