### PR TITLE
Avoid UART0 and SPI flash pins

### DIFF
--- a/examples/src/bin/embassy_i2c.rs
+++ b/examples/src/bin/embassy_i2c.rs
@@ -1,8 +1,8 @@
 //! Embassy I2C
 //!
 //! Folowing pins are used:
-//! SDA    GPIO1
-//! SCL    GPIO2
+//! SDA    GPIO4
+//! SCL    GPIO5
 //!
 //! Depending on your target and the board you are using you have to change the
 //! pins.
@@ -44,8 +44,8 @@ async fn main(_spawner: Spawner) {
 
     let i2c0 = I2C::new(
         peripherals.I2C0,
-        io.pins.gpio1,
-        io.pins.gpio2,
+        io.pins.gpio4,
+        io.pins.gpio5,
         400u32.kHz(),
         &clocks,
     );

--- a/examples/src/bin/gpio_interrupt.rs
+++ b/examples/src/bin/gpio_interrupt.rs
@@ -37,7 +37,7 @@ fn main() -> ! {
 
     // Set GPIO1 as an output, and set its state high initially.
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
-    let mut led = io.pins.gpio1.into_push_pull_output();
+    let mut led = io.pins.gpio2.into_push_pull_output();
 
     #[cfg(any(feature = "esp32", feature = "esp32s2", feature = "esp32s3"))]
     let mut button = io.pins.gpio0.into_pull_down_input();

--- a/examples/src/bin/gpio_interrupt.rs
+++ b/examples/src/bin/gpio_interrupt.rs
@@ -35,7 +35,7 @@ fn main() -> ! {
     let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
-    // Set GPIO1 as an output, and set its state high initially.
+    // Set GPIO2 as an output, and set its state high initially.
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let mut led = io.pins.gpio2.into_push_pull_output();
 

--- a/examples/src/bin/i2c_bmp180_calibration_data.rs
+++ b/examples/src/bin/i2c_bmp180_calibration_data.rs
@@ -3,8 +3,8 @@
 //! This example dumps the calibration data from a BMP180 sensor
 //!
 //! The following wiring is assumed:
-//! - SDA => GPIO1
-//! - SCL => GPIO2
+//! - SDA => GPIO4
+//! - SCL => GPIO5
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
 
@@ -27,8 +27,8 @@ fn main() -> ! {
     // I2C clock speed:
     let mut i2c = I2C::new(
         peripherals.I2C0,
-        io.pins.gpio1,
-        io.pins.gpio2,
+        io.pins.gpio4,
+        io.pins.gpio5,
         100u32.kHz(),
         &clocks,
     );

--- a/examples/src/bin/qspi_flash.rs
+++ b/examples/src/bin/qspi_flash.rs
@@ -8,6 +8,14 @@
 //! IO3             GPIO4
 //! CS              GPIO5
 //!
+//! Folowing pins are used for ESP32:
+//! SCLK            GPIO0
+//! MISO/IO0        GPIO2
+//! MOSI/IO1        GPIO4
+//! IO2             GPIO5
+//! IO3             GPIO13
+//! CS              GPIO14
+//!
 //! Depending on your target and the board you are using you have to change the
 //! pins.
 //!
@@ -43,12 +51,23 @@ fn main() -> ! {
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
-    let sclk = io.pins.gpio0;
-    let miso = io.pins.gpio1;
-    let mosi = io.pins.gpio2;
-    let sio2 = io.pins.gpio3;
-    let sio3 = io.pins.gpio4;
-    let cs = io.pins.gpio5;
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "esp32")] {
+            let sclk = io.pins.gpio0;
+            let miso = io.pins.gpio2;
+            let mosi = io.pins.gpio4;
+            let sio2 = io.pins.gpio5;
+            let sio3 = io.pins.gpio13;
+            let cs = io.pins.gpio14;
+        } else {
+            let sclk = io.pins.gpio0;
+            let miso = io.pins.gpio1;
+            let mosi = io.pins.gpio2;
+            let sio2 = io.pins.gpio3;
+            let sio3 = io.pins.gpio4;
+            let cs = io.pins.gpio5;
+        }
+    }
 
     let dma = Dma::new(peripherals.DMA);
     #[cfg(any(feature = "esp32", feature = "esp32s2"))]

--- a/examples/src/bin/spi_eh1_device_loopback.rs
+++ b/examples/src/bin/spi_eh1_device_loopback.rs
@@ -2,11 +2,19 @@
 //!
 //! Folowing pins are used:
 //! SCLK    GPIO0
-//! MISO    GPIO1
-//! MOSI    GPIO2
-//! CS 1    GPIO3
-//! CS 2    GPIO4
-//! CS 3    GPIO5
+//! MISO    GPIO2
+//! MOSI    GPIO4
+//! CS 1    GPIO5
+//! CS 2    GPIO6
+//! CS 3    GPIO7
+//!
+//! Folowing pins are used for ESP32:
+//! SCLK    GPIO0
+//! MISO    GPIO2
+//! MOSI    GPIO4
+//! CS 1    GPIO5
+//! CS 2    GPIO13
+//! CS 3    GPIO14
 //!
 //! Depending on your target and the board you are using you have to change the
 //! pins.
@@ -44,8 +52,8 @@ fn main() -> ! {
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let sclk = io.pins.gpio0;
-    let miso = io.pins.gpio1;
-    let mosi = io.pins.gpio2;
+    let miso = io.pins.gpio2;
+    let mosi = io.pins.gpio4;
 
     let spi_bus = Spi::new(peripherals.SPI2, 1000u32.kHz(), SpiMode::Mode0, &clocks).with_pins(
         Some(sclk),
@@ -55,11 +63,21 @@ fn main() -> ! {
     );
     let spi_bus = RefCell::new(spi_bus);
     let mut spi_device_1 =
-        RefCellDevice::new_no_delay(&spi_bus, io.pins.gpio3.into_push_pull_output());
-    let mut spi_device_2 =
-        RefCellDevice::new_no_delay(&spi_bus, io.pins.gpio4.into_push_pull_output());
-    let mut spi_device_3 =
         RefCellDevice::new_no_delay(&spi_bus, io.pins.gpio5.into_push_pull_output());
+
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "esp32")] {
+            let mut spi_device_2 =
+                RefCellDevice::new_no_delay(&spi_bus, io.pins.gpio13.into_push_pull_output());
+            let mut spi_device_3 =
+                RefCellDevice::new_no_delay(&spi_bus, io.pins.gpio14.into_push_pull_output());
+        } else {
+            let mut spi_device_2 =
+                RefCellDevice::new_no_delay(&spi_bus, io.pins.gpio4.into_push_pull_output());
+            let mut spi_device_3 =
+                RefCellDevice::new_no_delay(&spi_bus, io.pins.gpio5.into_push_pull_output());
+        }
+    }
 
     let mut delay = Delay::new(&clocks);
     println!("=== SPI example with embedded-hal-1 traits ===");

--- a/examples/src/bin/spi_eh1_device_loopback.rs
+++ b/examples/src/bin/spi_eh1_device_loopback.rs
@@ -73,9 +73,9 @@ fn main() -> ! {
                 RefCellDevice::new_no_delay(&spi_bus, io.pins.gpio14.into_push_pull_output());
         } else {
             let mut spi_device_2 =
-                RefCellDevice::new_no_delay(&spi_bus, io.pins.gpio4.into_push_pull_output());
+                RefCellDevice::new_no_delay(&spi_bus, io.pins.gpio6.into_push_pull_output());
             let mut spi_device_3 =
-                RefCellDevice::new_no_delay(&spi_bus, io.pins.gpio5.into_push_pull_output());
+                RefCellDevice::new_no_delay(&spi_bus, io.pins.gpio7.into_push_pull_output());
         }
     }
 

--- a/examples/src/bin/spi_eh1_loopback.rs
+++ b/examples/src/bin/spi_eh1_loopback.rs
@@ -2,9 +2,9 @@
 //!
 //! Folowing pins are used:
 //! SCLK    GPIO0
-//! MISO    GPIO1
-//! MOSI    GPIO2
-//! CS      GPIO3
+//! MISO    GPIO2
+//! MOSI    GPIO4
+//! CS      GPIO5
 //!
 //! Depending on your target and the board you are using you have to change the
 //! pins.
@@ -39,9 +39,9 @@ fn main() -> ! {
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let sclk = io.pins.gpio0;
-    let miso = io.pins.gpio1;
-    let mosi = io.pins.gpio2;
-    let cs = io.pins.gpio3;
+    let miso = io.pins.gpio2;
+    let mosi = io.pins.gpio4;
+    let cs = io.pins.gpio5;
 
     let mut spi = Spi::new(peripherals.SPI2, 1000u32.kHz(), SpiMode::Mode0, &clocks).with_pins(
         Some(sclk),

--- a/examples/src/bin/spi_halfduplex_read_manufacturer_id.rs
+++ b/examples/src/bin/spi_halfduplex_read_manufacturer_id.rs
@@ -8,6 +8,14 @@
 //! IO3             GPIO4
 //! CS              GPIO5
 //!
+//! Folowing pins are used for ESP32:
+//! SCLK            GPIO0
+//! MISO/IO0        GPIO2
+//! MOSI/IO1        GPIO4
+//! IO2             GPIO5
+//! IO3             GPIO13
+//! CS              GPIO14
+//!
 //! Depending on your target and the board you are using you have to change the
 //! pins.
 //!
@@ -41,12 +49,23 @@ fn main() -> ! {
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
-    let sclk = io.pins.gpio0;
-    let miso = io.pins.gpio1;
-    let mosi = io.pins.gpio2;
-    let sio2 = io.pins.gpio3;
-    let sio3 = io.pins.gpio4;
-    let cs = io.pins.gpio5;
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "esp32")] {
+            let sclk = io.pins.gpio0;
+            let miso = io.pins.gpio2;
+            let mosi = io.pins.gpio4;
+            let sio2 = io.pins.gpio5;
+            let sio3 = io.pins.gpio13;
+            let cs = io.pins.gpio14;
+        } else {
+            let sclk = io.pins.gpio0;
+            let miso = io.pins.gpio1;
+            let mosi = io.pins.gpio2;
+            let sio2 = io.pins.gpio3;
+            let sio3 = io.pins.gpio4;
+            let cs = io.pins.gpio5;
+        }
+    }
 
     let mut spi = Spi::new_half_duplex(peripherals.SPI2, 100u32.kHz(), SpiMode::Mode0, &clocks)
         .with_pins(

--- a/examples/src/bin/spi_loopback.rs
+++ b/examples/src/bin/spi_loopback.rs
@@ -2,9 +2,9 @@
 //!
 //! Folowing pins are used:
 //! SCLK    GPIO0
-//! MISO    GPIO1
-//! MOSI    GPIO2
-//! CS      GPIO3
+//! MISO    GPIO2
+//! MOSI    GPIO4
+//! CS      GPIO5
 //!
 //! Depending on your target and the board you are using you have to change the
 //! pins.
@@ -37,9 +37,9 @@ fn main() -> ! {
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let sclk = io.pins.gpio0;
-    let miso = io.pins.gpio1;
-    let mosi = io.pins.gpio2;
-    let cs = io.pins.gpio3;
+    let miso = io.pins.gpio2;
+    let mosi = io.pins.gpio4;
+    let cs = io.pins.gpio5;
 
     let mut spi = Spi::new(peripherals.SPI2, 100u32.kHz(), SpiMode::Mode0, &clocks).with_pins(
         Some(sclk),

--- a/examples/src/bin/spi_loopback_dma.rs
+++ b/examples/src/bin/spi_loopback_dma.rs
@@ -2,9 +2,9 @@
 //!
 //! Folowing pins are used:
 //! SCLK    GPIO0
-//! MISO    GPIO1
-//! MOSI    GPIO2
-//! CS      GPIO3
+//! MISO    GPIO2
+//! MOSI    GPIO4
+//! CS      GPIO5
 //!
 //! Depending on your target and the board you are using you have to change the
 //! pins.
@@ -42,9 +42,9 @@ fn main() -> ! {
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let sclk = io.pins.gpio0;
-    let miso = io.pins.gpio1;
-    let mosi = io.pins.gpio2;
-    let cs = io.pins.gpio3;
+    let miso = io.pins.gpio2;
+    let mosi = io.pins.gpio4;
+    let cs = io.pins.gpio5;
 
     let dma = Dma::new(peripherals.DMA);
 


### PR DESCRIPTION
Fixes the remaining examples to not use UART0 and the SPI flash pins

Examples which need "a lot" of pins now contain `cfg_if!` unfortunately since we cannot use GPIO 1,3,6,7,8,9,10,11 on ESP32

