### PR TITLE
Release esp-backtrace and esp-metadata

### DIFF
--- a/esp-backtrace/CHANGELOG.md
+++ b/esp-backtrace/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## Unreleased
 
 ### Added
 
@@ -14,6 +14,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### Removed
+
+## [0.15.1] - 2025-02-24
+
+### Fixed
+
+- `PanicInfo` is now printed natively by `defmt` (#3112)
 
 ## 0.15.0 - 2025-01-15
 
@@ -66,4 +72,4 @@ No changes - published to avoid conflicts with `esp-println`
 - Fix compilation for nightly after 2024-06-12. (#1681)
 - Only prints float registers on targets which have them. (#1690)
 
-[Unreleased]: https://github.com/esp-rs/esp-hal/commits/main/esp-backtrace?since=2025-01-15
+[0.15.1]: https://github.com/esp-rs/esp-hal/releases/tag/esp-backtrace-v0.15.1

--- a/esp-backtrace/Cargo.toml
+++ b/esp-backtrace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "esp-backtrace"
-version      = "0.15.0"
+version      = "0.15.1"
 edition      = "2021"
 rust-version = "1.84.0"
 description  = "Bare-metal backtrace support for Espressif devices"

--- a/esp-hal-embassy/Cargo.toml
+++ b/esp-hal-embassy/Cargo.toml
@@ -32,7 +32,7 @@ static_cell               = "2.1.0"
 [build-dependencies]
 esp-build    = { version = "0.2.0", path = "../esp-build" }
 esp-config   = { version = "0.3.0", path = "../esp-config", features = ["build"] }
-esp-metadata = { version = "0.5.0", path = "../esp-metadata" }
+esp-metadata = { version = "0.6.0", path = "../esp-metadata" }
 
 [features]
 default = ["executors"]

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -79,7 +79,7 @@ critical-section = { version = "1.2.0", features = ["restore-state-u32"] }
 basic-toml   = "0.1.9"
 cfg-if       = "1.0.0"
 esp-build    = { version = "0.2.0", path = "../esp-build" }
-esp-metadata = { version = "0.5.0", path = "../esp-metadata" }
+esp-metadata = { version = "0.6.0", path = "../esp-metadata" }
 esp-config   = { version = "0.3.0", path = "../esp-config", features = ["build"] }
 serde        = { version = "1.0.218", features = ["derive"] }
 

--- a/esp-metadata/CHANGELOG.md
+++ b/esp-metadata/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## Unreleased
 
 ### Added
 
@@ -14,6 +14,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### Removed
+
+## [0.6.0] - 2025-02-24
+
+### Added
+
+- Introduced the `adc1` and `adc2` symbols (#3082)
+
+### Removed
+
+- Removed the `adc` symbol (#3082)
 
 ## 0.5.0 - 2025-01-15
 
@@ -38,4 +48,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release
 
-[Unreleased]: https://github.com/esp-rs/esp-hal/commits/main/esp-metadata?since=2025-01-15
+[0.6.0]: https://github.com/esp-rs/esp-hal/releases/tag/esp-metadata-v0.6.0

--- a/esp-metadata/Cargo.toml
+++ b/esp-metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "esp-metadata"
-version      = "0.5.0"
+version      = "0.6.0"
 edition      = "2021"
 rust-version = "1.84.0"
 description  = "Metadata for Espressif devices"

--- a/esp-wifi/Cargo.toml
+++ b/esp-wifi/Cargo.toml
@@ -47,7 +47,7 @@ serde = { version = "1.0.218", default-features = false, features = ["derive"], 
 [build-dependencies]
 esp-build    = { version = "0.2.0", path = "../esp-build" }
 esp-config   = { version = "0.3.0", path = "../esp-config", features = ["build"] }
-esp-metadata = { version = "0.5.0", path = "../esp-metadata" }
+esp-metadata = { version = "0.6.0", path = "../esp-metadata" }
 
 [features]
 default = ["builtin-scheduler", "esp-alloc"]


### PR DESCRIPTION
These packages unfortunately missed out on some changelog entries, but I noticed they actually had some notable changes. I've retroactively documented these and prepared the release for them.